### PR TITLE
Added two new classes to be used to encapsulate the client/new payer …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,11 @@ This is a stubbed version of FHIRplace Handler to help with the creation of a wo
 
 The interactions with the FHIRplace Client have already been coded against all the elements within the current test cases.
 This includes all parsing of the test requests and placement of the test request element values into the corresponding container classes.
-You should only need to add your own FHIR implementation code in the specified sections of the ProcessTestRequest class for each test case.
+You should only need to add your own FHIR implementation code in the specified sections of the SendAsClient class (for New Payer) and/or the
+ReceiveAsServer class (for Old Payer) for each test case.
 
-Please note that there may be some confusion regarding the ProcessTestRequest respondToInitialSendOrReceive() method:
 The test requests require reporting, uploading and sometimes verification of certain pieces of the sending and receiving processes.
-In actuality, this is probably done in one step within the FHIR client send and FHIR server receive processes, however pieces of 
-this step will need to be extracted and uploaded individually.
-
-To accommodate this, you may record all the parts of your sending and receiving (requests and responses) into a container class,
-including any test statuses, HTTP responses, Access Token values, Member Identifiers, Patient Data, etc., and then extract those 
-values for recording the values identified in the provided stubbed source code and then test your updated code.
+The ProcessTestRequest class will take care of all that for you as long as you provide the correct within your SendAsClient / ReceiveAsServer implementations. These values are currently set with placeholder values. As part of your implementation, you may record all the parts of your sending and receiving (requests and responses) into these classes, including any test statuses, HTTP responses, Access Token values, Member Identifiers, Patient Data, and so on.  The ProcessTestRequest class will extract those values using the corresponding get() methods provided in these classes.
 
 
 ## Building the code

--- a/src/main/java/com/dgi/fhirplace/handler/ReceiveAsServer.java
+++ b/src/main/java/com/dgi/fhirplace/handler/ReceiveAsServer.java
@@ -1,0 +1,92 @@
+package com.dgi.fhirplace.handler;
+
+import com.dgi.fhirplace.parser.Transmission;
+
+/**
+ * This class encapsulates all the server (old payer) receiving from 
+ * the client (new payer) and returning the response to them.
+ * 
+ * You will need to update the response content from the
+ * appropriate response elements so that the ProcessTestRequest class
+ * can access them and send them to the FHIRplace server
+ */
+public class ReceiveAsServer {
+  
+  Logger log;
+
+  String testRequestID;
+  String partner;
+  String receiveDataType;
+  String fhirServer;
+  String authServer;
+  String patientResourceName;
+  String coverageResourceName;
+  
+  boolean receiveSuccess = true;
+  boolean responseSuccess = true;
+
+  String fhirID = "ABCDEFGHIJKLMNOP";
+  String accessToken = "123456789";
+  String clientID = "Some Client ID";
+  String headersAndMetaData = "Sent headers and metadata";
+  
+  /**
+   * This is the constructor that includes the necessary elements for receiving
+   * 
+   * @param testRequestID - the unique identifier for this test request
+   * @param receiveDataType - the type of data being received
+   * @param partner - the name of the participant that is sending the request
+   * @param trans - the transmission object parsed from the test request's Transmission element
+   * @param log -  a reference to the Logger object for logging as needed
+   */
+  public ReceiveAsServer(String testRequestID, String partner, String receiveDataType,
+                         Transmission trans, Logger log) {
+    this.testRequestID = testRequestID;
+    this.partner = partner;
+    this.receiveDataType = receiveDataType;
+
+    this.fhirServer = trans.getFhirServer();
+    this.authServer = trans.getAuthorizationServer();
+    this.patientResourceName = trans.getPatientResourceName();
+    this.coverageResourceName = trans.getCoverageResourceName();
+    
+    this.log = log;  
+  }
+  
+  public void receive() {
+    // When receiving, trigger off the receiveDataType value
+    log.write("The received data type is: " + receiveDataType);
+  }
+  
+  public void returnResponse(String dataType) {
+    log.write("Returning " + dataType + " response...");
+    
+    // Based on the dataType, you should return the correct response:
+    
+    // ClientID type
+    // AccessToken Type
+    // FHIR ID Type
+    // Headers and Metadata Type
+  }
+  
+  public boolean isReceiveSuccess() {
+    return this.receiveSuccess;
+  }
+  public boolean isResponseSuccess() {
+    return this.responseSuccess;
+  }
+
+  public String getFhirID() {
+    return this.fhirID;
+  }
+  public String getAccessToken() {
+    return this.accessToken;
+  }
+  public String getClientID() {
+    return this.clientID;
+  }
+  public String getHeadersAndMetaData() {
+    return this.headersAndMetaData;
+  }
+  
+}

--- a/src/main/java/com/dgi/fhirplace/handler/SendAsClient.java
+++ b/src/main/java/com/dgi/fhirplace/handler/SendAsClient.java
@@ -1,0 +1,108 @@
+package com.dgi.fhirplace.handler;
+
+import com.dgi.fhirplace.parser.Transmission;
+
+/**
+ * This class encapsulates all the client (new payer) sending to 
+ * the server (old payer) and receiving the response.
+ * 
+ * You will need to parse the response content and update the
+ * appropriate elements so that the ProcessTestRequest class
+ * can access them and send them to the FHIRplace server
+ */
+public class SendAsClient {
+
+  Logger log;
+
+  String testRequestID;
+  String partner;
+  String sendDataType;
+  String fhirServer;
+  String authServer;
+  String patientResourceName;
+  String coverageResourceName;
+  
+  boolean sendSuccess = true;
+  boolean responseSuccess = true;
+
+  String fhirID = "ABCDEFGHIJKLMNOP";
+  String accessToken = "123456789";
+  String clientID = "Some Client ID";
+  String headersAndMetaData = "Sent headers and metadata";
+  
+  /**
+   * This is the constructor that includes the necessary elements for sending
+   * 
+   * @param testRequestID - the unique identifier for this test request
+   * @param sendDataType - the type of data being sent
+   * @param partner - the name of the participant that is receiving your request
+   * @param trans - the transmission object parsed from the test request's Transmission element
+   * @param log - a reference to the Logger object for logging as needed
+   */
+  public SendAsClient(String testRequestID, String partner, String sendDataType,  
+                      Transmission trans, Logger log) {
+    this.testRequestID = testRequestID;
+    this.partner = partner;
+    this.sendDataType = sendDataType;
+
+    this.fhirServer = trans.getFhirServer();
+    this.authServer = trans.getAuthorizationServer();
+    this.patientResourceName = trans.getPatientResourceName();
+    this.coverageResourceName = trans.getCoverageResourceName();
+    
+    this.log = log;
+  }
+  
+  /**
+   * Use this method to send the message and wait for a response.
+   * After the response if received, if it was not successful,
+   * change the 'success' value to false.
+   * 
+   * If it was successful, update the FHIR_ID (Member ID)
+   * and the Access Token where appropriate
+   */
+  public void send() {
+    log.write("Sending request to " + partner);
+    
+    // Sit in a loop and wait for the response
+    
+    // Update the results
+  }
+  
+  /**
+   * This method receives the response if needed.
+   * You will either add code to receive the response or extract
+   * the result of the response from your initial message
+   * 
+   * @param dataType - the data type that is part of the response
+   */
+  public void receiveResponseForDataType(String dataType) {
+    log.write("Receiving " + dataType + " response...");
+    
+    // Based on the dataType, you should receive the correct response
+    // ClientID type
+    // AccessToken Type
+    // FHIR ID Type
+    // Headers and Metadata Type
+  }
+  
+  public boolean isSendSuccess() {
+    return this.sendSuccess;
+  }
+  public boolean isResponseSuccess() {
+    return this.responseSuccess;
+  }
+
+  public String getFhirID() {
+    return this.fhirID;
+  }
+  public String getAccessToken() {
+    return this.accessToken;
+  }
+  public String getClientID() {
+    return this.clientID;
+  }
+  public String getHeadersAndMetaData() {
+    return this.headersAndMetaData;
+  }          
+}


### PR DESCRIPTION
…sending to the server and the receiving as server/old payer from the server.

With this update, nothing should need to be updated within the ProcessTestRequest class.  The implementors of these classes only need to add their specialized sending and receiving to these classes.